### PR TITLE
Update Ruby version in Android Fastlane workflow

### DIFF
--- a/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
+++ b/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.3.3"
+        ruby-version: "3.2.3"
         bundler-cache: true
         working-directory: android
         


### PR DESCRIPTION
Changed the Ruby version from 3.3.3 to 3.2.3 in the GitHub Actions workflow for Android Fastlane Firebase App Distribution. This ensures compatibility and stability with the current project dependencies.