### PR TITLE
Add dependency installation and environment print steps

### DIFF
--- a/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
+++ b/.github/workflows/android_fastlane_firebase_app_distribution_workflow.yml
@@ -30,6 +30,19 @@ jobs:
         bundler-cache: true
         working-directory: android
         
+    - name: Install dependencies
+      run: |
+        bundle install
+      working-directory: android
+
+    - name: Print Bundler and Ruby environment
+      run: |
+        ruby -v
+        bundle -v
+        gem env
+        bundle config
+      working-directory: android
+
     - name: Build and Distribute App
       env:
         FIREBASE_CLI_TOKEN: ${{ secrets.FIREBASE_CLI_TOKEN }}


### PR DESCRIPTION
Added steps to install dependencies using Bundler and print the Bundler and Ruby environment details in the Android Fastlane Firebase App Distribution workflow. This ensures that the necessary gems are installed and provides visibility into the environment configuration before building and distributing the app.